### PR TITLE
Fix Claude workflow permissions to allow write access

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,10 +25,10 @@ jobs:
       (github.event_name == 'discussion_comment' && contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      discussions: read
+      contents: write
+      pull-requests: write
+      issues: write
+      discussions: write
       id-token: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Fix "401 Unauthorized - User does not have write access" error in Claude Code Review action
- Change permissions from `read` to `write` for contents, pull-requests, issues, and discussions
- This allows the Claude action to properly post comments and interact with repository content

## Test plan
- [ ] Verify Claude action can post comments on issues after merge
- [ ] Test @claude mentions in PR comments work without permission errors
- [ ] Confirm workflow runs successfully without authentication failures

🤖 Generated with [Claude Code](https://claude.ai/code)