### PR TITLE
Enable Claude assignee trigger for GitHub App

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,7 +49,7 @@ jobs:
           # trigger_phrase: "/claude"
           
           # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
+          assignee_trigger: "claude"
           
           # Optional: Allow Claude to run specific commands
           # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"


### PR DESCRIPTION
## Summary
- Enable assignee trigger to respond when the @claude GitHub App is assigned to issues
- Uncomment and configure `assignee_trigger: "claude"` in the workflow
- This provides an additional way to activate Claude besides @mentions

## Test plan
- [ ] Assign an issue to the @claude GitHub App and verify it triggers the workflow
- [ ] Confirm existing @claude mention triggers continue to work

This complements the existing trigger methods:
- @claude mentions in comments, titles, descriptions
- Assignment to the official Claude GitHub App

🤖 Generated with [Claude Code](https://claude.ai/code)